### PR TITLE
fetch weather data

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+HTTPS=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -2281,6 +2281,15 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
       "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig=="
     },
+    "@types/axios": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
+      "integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
+      "dev": true,
+      "requires": {
+        "axios": "*"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.15",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
@@ -3196,6 +3205,14 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.3.tgz",
       "integrity": "sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA=="
+    },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^12.20.23",
     "@types/react": "^17.0.19",
     "@types/react-dom": "^17.0.9",
+    "axios": "^0.21.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.4",
@@ -45,6 +46,7 @@
     ]
   },
   "devDependencies": {
+    "@types/axios": "^0.14.0",
     "@types/styled-components": "^5.1.14",
     "prettier": "^2.3.2"
   }

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Weather App</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,13 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500;700&family=Raleway:wght@100;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+
     <title>Weather App</title>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,11 @@
+import WeatherApp from "./components/WeatherApp";
+
 function App() {
-  return <div></div>;
+  return (
+    <div>
+      <WeatherApp />
+    </div>
+  );
 }
 
 export default App;

--- a/src/components/WeatherApp.tsx
+++ b/src/components/WeatherApp.tsx
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
+import type { VFC } from "react";
 
 axios.defaults.baseURL = "https://www.metaweather.com";
 
@@ -24,7 +25,7 @@ const ERROR_MESSAGE: { [key: number]: string } = {
   3: "位置情報の取得に時間がかかり過ぎてタイムアウトしました…。",
 };
 
-const WeatherApp = () => {
+const WeatherApp: VFC = () => {
   const [weatherData, setWeatherData] = useState(null);
 
   useEffect(() => {

--- a/src/components/WeatherApp.tsx
+++ b/src/components/WeatherApp.tsx
@@ -25,7 +25,7 @@ export interface ConsolidatedWeather {
   [key: number]: Weather;
 }
 
-const optionObj: PositionOptions = {
+const POS_OPTION: PositionOptions = {
   enableHighAccuracy: false,
   timeout: 3000,
   maximumAge: 0,
@@ -79,7 +79,7 @@ const WeatherApp: VFC = () => {
       navigator.geolocation.getCurrentPosition(
         successFunc,
         errorFunc,
-        optionObj
+        POS_OPTION
       );
     } else {
       alert("Geolocation API がサポートされていません");

--- a/src/components/WeatherApp.tsx
+++ b/src/components/WeatherApp.tsx
@@ -6,6 +6,25 @@ axios.defaults.baseURL = "https://www.metaweather.com";
 
 type Coords = Pick<GeolocationCoordinates, "latitude" | "longitude">;
 
+export interface Weather {
+  air_pressure: number;
+  humidity: number;
+  max_temp: number;
+  min_temp: number;
+  predictability: number;
+  the_temp: number;
+  visibility: number;
+  weather_state_abbr: string;
+  weather_state_name: string;
+  wind_direction: number;
+  wind_direction_compass: string;
+  wind_speed: number;
+}
+
+export interface ConsolidatedWeather {
+  [key: number]: Weather;
+}
+
 const optionObj: PositionOptions = {
   enableHighAccuracy: false,
   timeout: 3000,
@@ -26,7 +45,9 @@ const ERROR_MESSAGE: { [key: number]: string } = {
 };
 
 const WeatherApp: VFC = () => {
-  const [weatherData, setWeatherData] = useState(null);
+  const [weatherData, setWeatherData] = useState<ConsolidatedWeather | null>(
+    null
+  );
 
   useEffect(() => {
     const fetchWeatherData = async (coords: Coords) => {
@@ -39,7 +60,7 @@ const WeatherApp: VFC = () => {
           `/api/location/${locationData?.data[0]?.woeid}`
         );
 
-        setWeatherData(weatherData.data);
+        setWeatherData(weatherData.data.consolidated_weather);
       } catch (e) {
         alert(e);
       }

--- a/src/components/WeatherApp.tsx
+++ b/src/components/WeatherApp.tsx
@@ -50,7 +50,7 @@ const WeatherApp: VFC = () => {
   );
 
   useEffect(() => {
-    const fetchWeatherData = async (coords: Coords) => {
+    const fetchWeatherData = async (coords: Coords): Promise<void> => {
       try {
         const locationData = await axios.get(
           `/api/location/search/?lattlong=${coords.latitude},${coords.longitude}`

--- a/src/components/WeatherApp.tsx
+++ b/src/components/WeatherApp.tsx
@@ -1,0 +1,41 @@
+import axios from "axios";
+import { useEffect } from "react";
+
+axios.defaults.baseURL = "https://www.metaweather.com";
+
+const optionObj: PositionOptions = {
+  enableHighAccuracy: false,
+  timeout: 3000,
+  maximumAge: 0,
+};
+
+const ERROR_MESSAGE: { [key: number]: string } = {
+  0: "原因不明のエラーが発生しました…。",
+  1: "位置情報の取得が許可されませんでした…。",
+  2: "電波状況などで位置情報が取得できませんでした…。",
+  3: "位置情報の取得に時間がかかり過ぎてタイムアウトしました…。",
+};
+
+const WeatherApp = () => {
+  useEffect(() => {
+    const successFunc: PositionCallback = ({ coords }) => {};
+
+    const errorFunc: PositionErrorCallback = (error) => {
+      alert(ERROR_MESSAGE[error.code]);
+    };
+
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        successFunc,
+        errorFunc,
+        optionObj
+      );
+    } else {
+      alert("Geolocation API がサポートされていません");
+    }
+  }, []);
+
+  return <div></div>;
+};
+
+export default WeatherApp;

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,12 @@
-body {
-  margin: 0;
-  font-family: "Montserrat", "Raleway", -apple-system, BlinkMacSystemFont,
+:root {
+  --base-font: "Montserrat", "Raleway", -apple-system, BlinkMacSystemFont,
     "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
     "Droid Sans", "Helvetica Neue", sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
+body {
+  margin: 0;
+  font-family: var(--base-font);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,13 @@
     "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
+*,
+*::before,
+*::after {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   font-family: var(--base-font);

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,8 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+  font-family: "Montserrat", "Raleway", -apple-system, BlinkMacSystemFont,
+    "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
+    "Droid Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
## 追加内容　21/09/18

1. `npm start`で`localhost`を`https`で開くための設定ファイルを追加

## 追加内容
1. アプリケーションのタイトルを`Weather App`へ変更
2. 使用するフォントの追加(`Montserrat`, `Raleway`)
3. `axios`をインストール
4. `:root`セレクタを追加し、`--base-font`を設定、`body`内で`--base-font`を参照
5. `*,*::before,*::after`セレクタを追加、プロパティの設定
6. `geolocation`APIで自身のロケーションを取得
7. `metaweather`APIを用いて天気データを取得
8. `WeatherApp`コンポーネントを追加
9. `WeatherApp`functionコンポーネントに型を追加
10. ステートに保存するデータを変更(`weatherData.data`->`weatherData.data.consolidated_weather`)、それに伴い型を追加し、`usestate`に型を設定
11. `fetchWeatherData`に戻り型を追加
12. 定数名を変更(`optionObj`->`POS_OPTION`)