### PR TITLE
アプリをレスポンシブに対応させる　Feature/responsive

### DIFF
--- a/src/components/ChangeDegree.tsx
+++ b/src/components/ChangeDegree.tsx
@@ -30,7 +30,7 @@ const ChangeDegreeContainer = styled.div`
     text-align: right;
   }
 
-  @media screen and (max-width: 1339px) {
+  @media screen and (max-width: 1024px) {
     display: none;
   }
 

--- a/src/components/ChangeDegree.tsx
+++ b/src/components/ChangeDegree.tsx
@@ -26,7 +26,13 @@ const ChangeDegree = () => {
 };
 
 const ChangeDegreeContainer = styled.div`
-  text-align: right;
+  @media screen and (min-width: 1340px) {
+    text-align: right;
+  }
+
+  @media screen and (max-width: 1339px) {
+    display: none;
+  }
 
   > button:not(:first-child) {
     margin-left: 12px;

--- a/src/components/ChangeDegree.tsx
+++ b/src/components/ChangeDegree.tsx
@@ -26,9 +26,7 @@ const ChangeDegree = () => {
 };
 
 const ChangeDegreeContainer = styled.div`
-  @media screen and (min-width: 1340px) {
-    text-align: right;
-  }
+  text-align: right;
 
   @media screen and (max-width: 1024px) {
     display: none;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -23,7 +23,7 @@ const FooterSign = styled.footer`
   @media screen and (min-width: 1340px) {
     margin-top: 112px;
   }
-  @media screen and (max-width: 1339px) {
+  @media screen and (max-width: 1024px) {
     margin-top: 96px;
   }
 `;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,11 +14,17 @@ const FooterSign = styled.footer`
   font-size: 14px;
   font-weight: 500;
   text-align: center;
-  margin-top: 112px;
 
   > span {
     font-weight: 700;
     border-bottom: solid 1px;
+  }
+
+  @media screen and (min-width: 1340px) {
+    margin-top: 112px;
+  }
+  @media screen and (max-width: 1339px) {
+    margin-top: 96px;
   }
 `;
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,15 +14,13 @@ const FooterSign = styled.footer`
   font-size: 14px;
   font-weight: 500;
   text-align: center;
+  margin-top: 112px;
 
   > span {
     font-weight: 700;
     border-bottom: solid 1px;
   }
 
-  @media screen and (min-width: 1340px) {
-    margin-top: 112px;
-  }
   @media screen and (max-width: 1024px) {
     margin-top: 96px;
   }

--- a/src/components/Highlights.tsx
+++ b/src/components/Highlights.tsx
@@ -95,6 +95,10 @@ const HighlightWrapper = styled.div`
   @media screen and (max-width: 1024px) {
     margin-top: 51px;
   }
+
+  @media screen and (max-width: 767px) {
+    padding: 0 calc((100% - 328px) / 2);
+  }
 `;
 
 const HighlightHeader = styled.div`

--- a/src/components/Highlights.tsx
+++ b/src/components/Highlights.tsx
@@ -90,7 +90,14 @@ const Highlights = () => {
 
 const HighlightWrapper = styled.div`
   color: #e7e7eb;
-  margin-top: 72px;
+
+  @media screen and (min-width: 1340px) {
+    margin-top: 72px;
+  }
+
+  @media screen and (max-width: 1339px) {
+    margin-top: 51px;
+  }
 `;
 
 const HighlightHeader = styled.div`
@@ -102,7 +109,14 @@ const HighlightContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
   margin-top: 32px;
-  gap: 48px;
+
+  @media screen and (min-width: 1340px) {
+    gap: 48px;
+  }
+
+  @media screen and (max-width: 1339px) {
+    gap: 32px;
+  }
 `;
 
 const Tile = styled.div`

--- a/src/components/Highlights.tsx
+++ b/src/components/Highlights.tsx
@@ -95,7 +95,7 @@ const HighlightWrapper = styled.div`
     margin-top: 72px;
   }
 
-  @media screen and (max-width: 1339px) {
+  @media screen and (max-width: 1024px) {
     margin-top: 51px;
   }
 `;
@@ -114,7 +114,7 @@ const HighlightContainer = styled.div`
     gap: 48px;
   }
 
-  @media screen and (max-width: 1339px) {
+  @media screen and (max-width: 1024px) {
     gap: 32px;
   }
 `;

--- a/src/components/Highlights.tsx
+++ b/src/components/Highlights.tsx
@@ -90,10 +90,7 @@ const Highlights = () => {
 
 const HighlightWrapper = styled.div`
   color: #e7e7eb;
-
-  @media screen and (min-width: 1340px) {
-    margin-top: 72px;
-  }
+  margin-top: 72px;
 
   @media screen and (max-width: 1024px) {
     margin-top: 51px;
@@ -109,10 +106,7 @@ const HighlightContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
   margin-top: 32px;
-
-  @media screen and (min-width: 1340px) {
-    gap: 48px;
-  }
+  gap: 48px;
 
   @media screen and (max-width: 1024px) {
     gap: 32px;

--- a/src/components/Highlights.tsx
+++ b/src/components/Highlights.tsx
@@ -105,6 +105,7 @@ const HighlightHeader = styled.div`
 const HighlightContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   margin-top: 32px;
   gap: 48px;
 

--- a/src/components/NextWeather.tsx
+++ b/src/components/NextWeather.tsx
@@ -62,9 +62,8 @@ const NextWeatherUl = styled.ul`
 
   @media screen and (max-width: 1024px) {
     flex-wrap: wrap;
+    justify-content: center;
     margin: 0;
-    padding: 0 23px;
-    gap: 32px;
   }
 `;
 

--- a/src/components/NextWeather.tsx
+++ b/src/components/NextWeather.tsx
@@ -49,6 +49,8 @@ const NextWeatherUl = styled.ul`
   padding: 0;
   font-weight: 500;
   font-size: 16px;
+  margin-top: 66px;
+  column-gap: 26px;
 
   > li {
     width: 120px;
@@ -56,11 +58,6 @@ const NextWeatherUl = styled.ul`
     padding: 18px 0;
     text-align: center;
     background-color: #1e213a;
-  }
-
-  @media screen and (min-width: 1340px) {
-    margin-top: 66px;
-    column-gap: 26px;
   }
 
   @media screen and (max-width: 1024px) {

--- a/src/components/NextWeather.tsx
+++ b/src/components/NextWeather.tsx
@@ -65,6 +65,12 @@ const NextWeatherUl = styled.ul`
     justify-content: center;
     margin: 0;
   }
+
+  @media screen and (max-width: 767px) {
+    padding: 0 calc((100% - 266px) / 2);
+    justify-content: flex-start;
+    gap: 32px 26px;
+  }
 `;
 
 const ImageContainer = styled.div`

--- a/src/components/NextWeather.tsx
+++ b/src/components/NextWeather.tsx
@@ -63,7 +63,7 @@ const NextWeatherUl = styled.ul`
     column-gap: 26px;
   }
 
-  @media screen and (max-width: 1339px) {
+  @media screen and (max-width: 1024px) {
     flex-wrap: wrap;
     margin: 0;
     padding: 0 23px;

--- a/src/components/NextWeather.tsx
+++ b/src/components/NextWeather.tsx
@@ -47,10 +47,8 @@ const NextWeatherUl = styled.ul`
   list-style: none;
   display: flex;
   padding: 0;
-  column-gap: 26px;
   font-weight: 500;
   font-size: 16px;
-  margin-top: 66px;
 
   > li {
     width: 120px;
@@ -58,6 +56,18 @@ const NextWeatherUl = styled.ul`
     padding: 18px 0;
     text-align: center;
     background-color: #1e213a;
+  }
+
+  @media screen and (min-width: 1340px) {
+    margin-top: 66px;
+    column-gap: 26px;
+  }
+
+  @media screen and (max-width: 1339px) {
+    flex-wrap: wrap;
+    margin: 0;
+    padding: 0 23px;
+    gap: 32px;
   }
 `;
 

--- a/src/components/SearchLocation.tsx
+++ b/src/components/SearchLocation.tsx
@@ -82,6 +82,11 @@ const SearchLocation = () => {
 
 const SearchContainer = styled.div`
   padding: 12px 46px;
+
+  @media screen and (max-width: 1024px) {
+    width: 100vw;
+    padding: 12px calc((100vw - 350px) / 2);
+  }
 `;
 
 const SearchHeader = styled.header`

--- a/src/components/TodayWeather.tsx
+++ b/src/components/TodayWeather.tsx
@@ -129,7 +129,7 @@ const TodayWeatherWrapper = styled.div`
     background-size: auto;
   }
 
-  @media screen and (max-width: 1339px) {
+  @media screen and (max-width: 1024px) {
     padding: 18px 12px;
     background-position: -100px 62px;
     background-size: 580px;
@@ -151,7 +151,7 @@ const ImageContainer = styled.div`
     height: 250px;
   }
 
-  @media screen and (max-width: 1339px) {
+  @media screen and (max-width: 1024px) {
     margin-top: 70px;
 
     > img {
@@ -171,7 +171,7 @@ const Temperature = styled.div`
     color: #a09fb1;
   }
 
-  @media screen and (max-width: 1339px) {
+  @media screen and (max-width: 1024px) {
     margin-top: 35px;
   }
 `;
@@ -181,7 +181,7 @@ const WeatherName = styled.div`
   font-weight: 600;
   font-size: 36px;
 
-  @media screen and (max-width: 1339px) {
+  @media screen and (max-width: 1024px) {
     margin-top: 23px;
   }
 `;
@@ -191,7 +191,7 @@ const Day = styled.div`
   font-weight: 500;
   font-size: 18px;
 
-  @media screen and (max-width: 1339px) {
+  @media screen and (max-width: 1024px) {
     margin-top: 45px;
   }
 `;

--- a/src/components/TodayWeather.tsx
+++ b/src/components/TodayWeather.tsx
@@ -119,23 +119,45 @@ const TodayWeather: VFC = () => {
 
 const TodayWeatherWrapper = styled.div`
   position: relative;
-  padding: 46px;
   text-align: center;
   background-image: url(${backgroundImage});
   background-repeat: no-repeat;
-  background-size: auto;
-  background-position: -110px 103px;
+
+  @media screen and (min-width: 1340px) {
+    padding: 46px;
+    background-position: -110px 103px;
+    background-size: auto;
+  }
+
+  @media screen and (max-width: 1339px) {
+    padding: 18px 12px;
+    background-position: -100px 62px;
+    background-size: 580px;
+  }
 `;
 
 const TodayWeatherContainer = styled.div`
-  > div:not(:last-child) {
-    margin-top: 87px;
+  @media screen and (min-width: 1340px) {
+    > div:not(:last-child) {
+      margin-top: 87px;
+    }
   }
 `;
 
 const ImageContainer = styled.div`
   display: inline-block;
-  height: 250px;
+
+  @media screen and (min-width: 1340px) {
+    height: 250px;
+  }
+
+  @media screen and (max-width: 1339px) {
+    margin-top: 70px;
+
+    > img {
+      height: 174px;
+    }
+  }
 `;
 
 const Temperature = styled.div`
@@ -148,18 +170,30 @@ const Temperature = styled.div`
     font-size: 48px;
     color: #a09fb1;
   }
+
+  @media screen and (max-width: 1339px) {
+    margin-top: 35px;
+  }
 `;
 
 const WeatherName = styled.div`
   color: #a09fb1;
   font-weight: 600;
   font-size: 36px;
+
+  @media screen and (max-width: 1339px) {
+    margin-top: 23px;
+  }
 `;
 
 const Day = styled.div`
   color: #88869d;
   font-weight: 500;
   font-size: 18px;
+
+  @media screen and (max-width: 1339px) {
+    margin-top: 45px;
+  }
 `;
 
 const Place = styled.div`

--- a/src/components/TodayWeather.tsx
+++ b/src/components/TodayWeather.tsx
@@ -128,8 +128,7 @@ const TodayWeatherWrapper = styled.div`
 
   @media screen and (max-width: 1024px) {
     padding: 18px 12px;
-    background-position: -100px 62px;
-    background-size: 580px;
+    background-position: 50% 15%;
   }
 `;
 

--- a/src/components/TodayWeather.tsx
+++ b/src/components/TodayWeather.tsx
@@ -122,12 +122,9 @@ const TodayWeatherWrapper = styled.div`
   text-align: center;
   background-image: url(${backgroundImage});
   background-repeat: no-repeat;
-
-  @media screen and (min-width: 1340px) {
-    padding: 46px;
-    background-position: -110px 103px;
-    background-size: auto;
-  }
+  padding: 46px;
+  background-position: -110px 103px;
+  background-size: auto;
 
   @media screen and (max-width: 1024px) {
     padding: 18px 12px;
@@ -137,7 +134,7 @@ const TodayWeatherWrapper = styled.div`
 `;
 
 const TodayWeatherContainer = styled.div`
-  @media screen and (min-width: 1340px) {
+  @media screen and (min-width: 1025px) {
     > div:not(:last-child) {
       margin-top: 87px;
     }
@@ -146,10 +143,7 @@ const TodayWeatherContainer = styled.div`
 
 const ImageContainer = styled.div`
   display: inline-block;
-
-  @media screen and (min-width: 1340px) {
-    height: 250px;
-  }
+  height: 250px;
 
   @media screen and (max-width: 1024px) {
     margin-top: 70px;

--- a/src/components/TodayWeather.tsx
+++ b/src/components/TodayWeather.tsx
@@ -77,7 +77,7 @@ const TodayWeather: VFC = () => {
       {!todayWeatherData || !location ? (
         <Loading>Loading...</Loading>
       ) : (
-        <TodayWeatherContainer>
+        <div>
           <TodayWeatherHeader>
             <SearchButton
               onClick={() => {
@@ -111,7 +111,7 @@ const TodayWeather: VFC = () => {
             <MaterialIcon className="material-icons">location_on</MaterialIcon>
             {location.title}
           </Place>
-        </TodayWeatherContainer>
+        </div>
       )}
     </TodayWeatherWrapper>
   );
@@ -132,17 +132,10 @@ const TodayWeatherWrapper = styled.div`
   }
 `;
 
-const TodayWeatherContainer = styled.div`
-  @media screen and (min-width: 1025px) {
-    > div:not(:last-child) {
-      margin-top: 87px;
-    }
-  }
-`;
-
 const ImageContainer = styled.div`
   display: inline-block;
   height: 250px;
+  margin-top: 87px;
 
   @media screen and (max-width: 1024px) {
     margin-top: 70px;
@@ -157,6 +150,7 @@ const Temperature = styled.div`
   font-weight: 500;
   font-size: 144px;
   color: #e7e7eb;
+  margin-top: 87px;
 
   > span {
     font-weight: 100;
@@ -173,6 +167,7 @@ const WeatherName = styled.div`
   color: #a09fb1;
   font-weight: 600;
   font-size: 36px;
+  margin-top: 87px;
 
   @media screen and (max-width: 1024px) {
     margin-top: 23px;
@@ -183,6 +178,7 @@ const Day = styled.div`
   color: #88869d;
   font-weight: 500;
   font-size: 18px;
+  margin-top: 87px;
 
   @media screen and (max-width: 1024px) {
     margin-top: 45px;

--- a/src/components/WeatherApp.tsx
+++ b/src/components/WeatherApp.tsx
@@ -161,16 +161,10 @@ const MainContainer = styled.div<{ isShowSearch: boolean }>`
   overflow-y: auto;
   width: 459px;
   height: 1023px;
-  border-radius: 10px 0 0 10px;
 
   @media screen and (max-width: 1024px) {
     width: 100%;
 
-    ${({ isShowSearch }) => css`
-      ${isShowSearch
-        ? `border-radius: 10px 10px 10px 10px;`
-        : `border-radius: 10px 10px 0 0;`}
-    `}
     ${({ isShowSearch }) => css`
       ${isShowSearch ? `height: 100vh;` : `height: 810px;`}
     `}
@@ -183,13 +177,11 @@ const SubContainer = styled.div<{ isShowSearch: boolean }>`
   width: 981px;
   height: 1023px;
   padding: 42px 123px 0 154px;
-  border-radius: 0 10px 10px 0;
 
   @media screen and (max-width: 1024px) {
     width: 100%;
     height: auto;
     padding: 52px 23px 24px;
-    border-radius: 0 0 10px 10px;
 
     ${({ isShowSearch }) => css`
       ${isShowSearch &&

--- a/src/components/WeatherApp.tsx
+++ b/src/components/WeatherApp.tsx
@@ -164,7 +164,7 @@ const MainContainer = styled.div<{ isShowSearch: boolean }>`
   border-radius: 10px 0 0 10px;
 
   @media screen and (max-width: 1024px) {
-    width: 375px;
+    width: 100%;
 
     ${({ isShowSearch }) => css`
       ${isShowSearch
@@ -172,7 +172,7 @@ const MainContainer = styled.div<{ isShowSearch: boolean }>`
         : `border-radius: 10px 10px 0 0;`}
     `}
     ${({ isShowSearch }) => css`
-      ${isShowSearch ? `height: 672px;` : `height: 810px;`}
+      ${isShowSearch ? `height: 100vh;` : `height: 810px;`}
     `}
   }
 `;
@@ -186,9 +186,9 @@ const SubContainer = styled.div<{ isShowSearch: boolean }>`
   border-radius: 0 10px 10px 0;
 
   @media screen and (max-width: 1024px) {
-    width: 375px;
-    height: 1718px;
-    padding: 52px 23px 0;
+    width: 100%;
+    height: auto;
+    padding: 52px 23px 24px;
     border-radius: 0 0 10px 10px;
 
     ${({ isShowSearch }) => css`

--- a/src/components/WeatherApp.tsx
+++ b/src/components/WeatherApp.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import type { VFC, Dispatch } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import TodayWeather from "./TodayWeather";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import SearchLocation from "./SearchLocation";
 import {
   saveLocationData,
@@ -133,10 +133,10 @@ const WeatherApp: VFC = () => {
 
   return (
     <AppContainer>
-      <MainContainer>
+      <MainContainer isShowSearch={isShowSearch}>
         {isShowSearch ? <SearchLocation /> : <TodayWeather />}
       </MainContainer>
-      <SubContainer>
+      <SubContainer isShowSearch={isShowSearch}>
         <ChangeDegree />
         <NextWeather />
         <Highlights />
@@ -156,7 +156,7 @@ const AppContainer = styled.div`
   }
 `;
 
-const MainContainer = styled.div`
+const MainContainer = styled.div<{ isShowSearch: boolean }>`
   background-color: #1e213a;
   overflow-y: auto;
 
@@ -168,12 +168,19 @@ const MainContainer = styled.div`
 
   @media screen and (max-width: 1339px) {
     width: 375px;
-    height: 810px;
-    border-radius: 10px 10px 0 0;
+
+    ${({ isShowSearch }) => css`
+      ${isShowSearch
+        ? `border-radius: 10px 10px 10px 10px;`
+        : `border-radius: 10px 10px 0 0;`}
+    `}
+    ${({ isShowSearch }) => css`
+      ${isShowSearch ? `height: 672px;` : `height: 810px;`}
+    `}
   }
 `;
 
-const SubContainer = styled.div`
+const SubContainer = styled.div<{ isShowSearch: boolean }>`
   background: #100e1d;
   color: #e7e7eb;
 
@@ -189,6 +196,13 @@ const SubContainer = styled.div`
     height: 1718px;
     padding: 52px 23px 0;
     border-radius: 0 0 10px 10px;
+
+    ${({ isShowSearch }) => css`
+      ${isShowSearch &&
+      `
+      display: none;
+    `}
+    `}
   }
 `;
 

--- a/src/components/WeatherApp.tsx
+++ b/src/components/WeatherApp.tsx
@@ -159,12 +159,9 @@ const AppContainer = styled.div`
 const MainContainer = styled.div<{ isShowSearch: boolean }>`
   background-color: #1e213a;
   overflow-y: auto;
-
-  @media screen and (min-width: 1340px) {
-    width: 459px;
-    height: 1023px;
-    border-radius: 10px 0 0 10px;
-  }
+  width: 459px;
+  height: 1023px;
+  border-radius: 10px 0 0 10px;
 
   @media screen and (max-width: 1024px) {
     width: 375px;
@@ -183,13 +180,10 @@ const MainContainer = styled.div<{ isShowSearch: boolean }>`
 const SubContainer = styled.div<{ isShowSearch: boolean }>`
   background: #100e1d;
   color: #e7e7eb;
-
-  @media screen and (min-width: 1340px) {
-    width: 981px;
-    height: 1023px;
-    padding: 42px 123px 0 154px;
-    border-radius: 0 10px 10px 0;
-  }
+  width: 981px;
+  height: 1023px;
+  padding: 42px 123px 0 154px;
+  border-radius: 0 10px 10px 0;
 
   @media screen and (max-width: 1024px) {
     width: 375px;

--- a/src/components/WeatherApp.tsx
+++ b/src/components/WeatherApp.tsx
@@ -151,7 +151,7 @@ const AppContainer = styled.div`
   position: relative;
   margin: 0 auto;
 
-  @media screen and (max-width: 1339px) {
+  @media screen and (max-width: 1024px) {
     flex-direction: column;
   }
 `;
@@ -166,7 +166,7 @@ const MainContainer = styled.div<{ isShowSearch: boolean }>`
     border-radius: 10px 0 0 10px;
   }
 
-  @media screen and (max-width: 1339px) {
+  @media screen and (max-width: 1024px) {
     width: 375px;
 
     ${({ isShowSearch }) => css`
@@ -191,7 +191,7 @@ const SubContainer = styled.div<{ isShowSearch: boolean }>`
     border-radius: 0 10px 10px 0;
   }
 
-  @media screen and (max-width: 1339px) {
+  @media screen and (max-width: 1024px) {
     width: 375px;
     height: 1718px;
     padding: 52px 23px 0;

--- a/src/components/WeatherApp.tsx
+++ b/src/components/WeatherApp.tsx
@@ -150,21 +150,46 @@ const AppContainer = styled.div`
   display: flex;
   position: relative;
   margin: 0 auto;
+
+  @media screen and (max-width: 1339px) {
+    flex-direction: column;
+  }
 `;
 
 const MainContainer = styled.div`
-  width: 459px;
-  height: 1023px;
   background-color: #1e213a;
   overflow-y: auto;
+
+  @media screen and (min-width: 1340px) {
+    width: 459px;
+    height: 1023px;
+    border-radius: 10px 0 0 10px;
+  }
+
+  @media screen and (max-width: 1339px) {
+    width: 375px;
+    height: 810px;
+    border-radius: 10px 10px 0 0;
+  }
 `;
 
 const SubContainer = styled.div`
-  width: 981px;
-  height: 1023px;
   background: #100e1d;
-  padding: 42px 123px 0 154px;
-  color: #e7e7eb; ;
+  color: #e7e7eb;
+
+  @media screen and (min-width: 1340px) {
+    width: 981px;
+    height: 1023px;
+    padding: 42px 123px 0 154px;
+    border-radius: 0 10px 10px 0;
+  }
+
+  @media screen and (max-width: 1339px) {
+    width: 375px;
+    height: 1718px;
+    padding: 52px 23px 0;
+    border-radius: 0 0 10px 10px;
+  }
 `;
 
 export default WeatherApp;


### PR DESCRIPTION
## 目的
https://devchallenges.io/challenges/mM1UIenRhK808W8qmLWv の `Figma`より
幅の違うパターンを切り替えれるようにする

## 追加内容
- 各コンポーネントにメディアクエリを用いて画面（ウィンドウ）幅に応じたスタイルを指定

## 確認手順
- PC上でGoogle Chrome Deveoper Toolsを開き
![dev-tools](https://user-images.githubusercontent.com/66302618/139521907-b78bce24-4d42-4773-a53d-5f40ae219605.PNG)
画像左側にある
![responsive-mark](https://user-images.githubusercontent.com/66302618/139521926-d2ef86e7-c8bb-401a-abba-da0007376d2a.PNG)
をクリックすることでブラウザがレスポンシブ表示になり、それぞれのデバイス幅に調節できるようになる
![res-top](https://user-images.githubusercontent.com/66302618/139522015-2dc5853a-07da-4b82-a043-311de2ed7901.PNG)
このようなバーが画面上部に追加され、ここに数値を直接入力するか、一番左のコンボボックスでデバイスを選択できる

- Developer Tools を使用せずPCブラウザの横幅を変えてもアプリの表示が変わります

## 変更結果
### 1025px以上
![キャプチャ7](https://user-images.githubusercontent.com/66302618/138887316-14149d86-46b4-4ce0-8e83-c35875a4bf0a.PNG)
### 1024px - 768pxの間
![max-width-1024](https://user-images.githubusercontent.com/66302618/139285406-9b8509e3-c93b-490f-baad-cd8392a4cdce.PNG)
### 767px以下
![max-width-767-1](https://user-images.githubusercontent.com/66302618/139285422-73922e7e-e3e7-4bba-b8fb-13ae3cb325cc.PNG)
![max-width-767-2](https://user-images.githubusercontent.com/66302618/139285431-47e2d63e-987a-4b9c-9e1c-8b5f14d43dec.PNG)
